### PR TITLE
main menu button tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ For disabling screen blanking/locking, it uses
 
 | Language   | Translated (%) |
 | ---------- | -------------- |
-| Arabic     | 100.00         |
+| Arabic     | 96.77          |
 | English    | 100.00         |
 | Estonian   | 100.00         |
-| French     | 100.00         |
-| Italian    | 100.00         |
-| Portuguese | 100.00         |
+| French     | 96.77          |
+| Italian    | 96.77          |
+| Portuguese | 96.77          |
 
 - Translations with less than 70% completion will not be embedded into the app

--- a/po/ar.po
+++ b/po/ar.po
@@ -91,3 +91,6 @@ msgstr "السلوك عند الإغلاق"
 
 msgid "Applies only while active"
 msgstr "ينطبق فقط أثناء التشغيل"
+
+msgid "Main Menu"
+msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -91,3 +91,6 @@ msgstr "Behavior on Closing"
 
 msgid "Applies only while active"
 msgstr "Applies only while active"
+
+msgid "Main Menu"
+msgstr "Main Menu"

--- a/po/et.po
+++ b/po/et.po
@@ -38,6 +38,9 @@ msgstr "Tühista"
 msgid "Close"
 msgstr "Sulge"
 
+msgid "Main Menu"
+msgstr "Peamenüü"
+
 msgid "Preferences"
 msgstr "Eelistused"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -91,3 +91,6 @@ msgstr "Comportement à la fermeture"
 
 msgid "Applies only while active"
 msgstr "S'applique uniquement lorsqu'actif"
+
+msgid "Main Menu"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -91,3 +91,6 @@ msgstr "Comportamento alla chiusura"
 
 msgid "Applies only while active"
 msgstr "Si applica solo mentre è attivo"
+
+msgid "Main Menu"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -91,3 +91,6 @@ msgstr "Comportamento Durante Fechamento"
 
 msgid "Applies only while active"
 msgstr "Aplica-se apenas enquanto ativo"
+
+msgid "Main Menu"
+msgstr ""

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -14,6 +14,7 @@ export class EN_UI_LABELS {
   static "Stimulator is active, do you want to close it?": string;
   static "Cancel": string;
   static "Close": string;
+  static "Main Menu": string;
   static "Preferences": string;
   static "Theme": string;
   static "System Theme": string;

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -28,5 +28,6 @@
     "Stimulator is running in the backround": "المحفز يعمل في الخلفية",
     "Ask Confirmation": "طلب تأكيد",
     "Behavior on Closing": "السلوك عند الإغلاق",
-    "Applies only while active": "ينطبق فقط أثناء التشغيل"
+    "Applies only while active": "ينطبق فقط أثناء التشغيل",
+    "Main Menu": ""
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -28,5 +28,6 @@
     "Stimulator is running in the backround": "Stimulator is running in the backround",
     "Ask Confirmation": "Ask Confirmation",
     "Behavior on Closing": "Behavior on Closing",
-    "Applies only while active": "Applies only while active"
+    "Applies only while active": "Applies only while active",
+    "Main Menu": "Main Menu"
 }

--- a/src/locales/et/translation.json
+++ b/src/locales/et/translation.json
@@ -11,6 +11,7 @@
     "Stimulator is active, do you want to close it?": "Stimulaator on aktiivne, kas soovid selle sulgeda?",
     "Cancel": "Tühista",
     "Close": "Sulge",
+    "Main Menu": "Peamenüü",
     "Preferences": "Eelistused",
     "Theme": "Teema",
     "System Theme": "Süsteemi teema",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -28,5 +28,6 @@
     "Stimulator is running in the backround": "Le Stimulateur s'exécute en arrière-plan",
     "Ask Confirmation": "Demander confirmation",
     "Behavior on Closing": "Comportement à la fermeture",
-    "Applies only while active": "S'applique uniquement lorsqu'actif"
+    "Applies only while active": "S'applique uniquement lorsqu'actif",
+    "Main Menu": ""
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -28,5 +28,6 @@
     "Stimulator is running in the backround": "Stimulator è in esecuzione in background",
     "Ask Confirmation": "Chiedi conferma",
     "Behavior on Closing": "Comportamento alla chiusura",
-    "Applies only while active": "Si applica solo mentre è attivo"
+    "Applies only while active": "Si applica solo mentre è attivo",
+    "Main Menu": ""
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -28,5 +28,6 @@
     "Stimulator is running in the backround": "Stimulator está rodando em segundo plano",
     "Ask Confirmation": "Pedir Confirmação",
     "Behavior on Closing": "Comportamento Durante Fechamento",
-    "Applies only while active": "Aplica-se apenas enquanto ativo"
+    "Applies only while active": "Aplica-se apenas enquanto ativo",
+    "Main Menu": ""
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,6 +231,7 @@ export class MainWindow {
     hamburger.set_primary(true);
     hamburger.set_popover(popover);
     hamburger.set_icon_name("open-menu-symbolic");
+    hamburger.set_tooltip_text(UI_LABELS["Main Menu"]);
     header.pack_start(hamburger);
 
     this.#createAction(


### PR DESCRIPTION
Main Menu button tooltip translatable string is added to consts.ts, /et/translation.json and et.po
Estonian translation is tested and working flawlessly.
I will let you do the rest with the translations, so that the translation scripts could not mess anything up.