### PR TITLE
Add branding colors

### DIFF
--- a/distro/io.github.sigmasd.stimulator.metainfo.xml
+++ b/distro/io.github.sigmasd.stimulator.metainfo.xml
@@ -324,4 +324,9 @@
   <provides>
     <binary>stimulator</binary>
   </provides>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#26a269</color>
+    <color type="primary" scheme_preference="dark">#1b744b</color>
+  </branding>
 </component>


### PR DESCRIPTION
Tested with https://docs.flathub.org/banner-preview/ the light color is picked from the icon

![grafik](https://github.com/sigmaSd/Stimulator/assets/5943908/295f8035-7d29-4006-99f6-2de32070b334)
