### PR TITLE
 Display the translator credits in the About dialog according to the current display language

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -94,3 +94,6 @@ msgstr "ينطبق فقط أثناء التشغيل"
 
 msgid "Main Menu"
 msgstr "القائمة الرئيسية"
+
+msgid "translator-credits"
+msgstr "Bedis Nbiba https://github.com/sigmaSd"

--- a/po/en.po
+++ b/po/en.po
@@ -94,3 +94,6 @@ msgstr "Applies only while active"
 
 msgid "Main Menu"
 msgstr "Main Menu"
+
+msgid "translator-credits"
+msgstr "translator-credits"

--- a/po/et.po
+++ b/po/et.po
@@ -94,3 +94,6 @@ msgstr "Käitumine sulgemisel"
 
 msgid "Applies only while active"
 msgstr "Rakendub ainult aktiivses olekus"
+
+msgid "translator-credits"
+msgstr "Meybo Nõmme https://github.com/meybonomme"

--- a/po/fr.po
+++ b/po/fr.po
@@ -94,3 +94,6 @@ msgstr "S'applique uniquement lorsqu'actif"
 
 msgid "Main Menu"
 msgstr "Menu Principal"
+
+msgid "translator-credits"
+msgstr "Bedis Nbiba https://github.com/sigmaSd"

--- a/po/it.po
+++ b/po/it.po
@@ -94,3 +94,6 @@ msgstr "Si applica solo mentre è attivo"
 
 msgid "Main Menu"
 msgstr "Menù principale"
+
+msgid "translator-credits"
+msgstr "Albano Battistella https://github.com/albanobattistella"

--- a/po/ja.po
+++ b/po/ja.po
@@ -96,4 +96,4 @@ msgid "Main Menu"
 msgstr "メインメニュー"
 
 msgid "translator-credits"
-msgstr "Nicholas La Roux https://github.com/laroux"
+msgstr "Nicholas La Roux https://github.com/larouxn"

--- a/po/ja.po
+++ b/po/ja.po
@@ -94,3 +94,6 @@ msgstr "作動中のみ適用されます"
 
 msgid "Main Menu"
 msgstr "メインメニュー"
+
+msgid "translator-credits"
+msgstr "Nicholas La Roux https://github.com/laroux"

--- a/po/nl.po
+++ b/po/nl.po
@@ -104,3 +104,6 @@ msgstr "Alleen indien actief"
 
 msgid "Main Menu"
 msgstr "Hoofdmenu"
+
+msgid "translator-credits"
+msgstr "Heimen Stoffels https://github.com/Vistaus"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -103,3 +103,6 @@ msgstr "Aplica-se apenas enquanto ativo"
 
 msgid "Main Menu"
 msgstr "Menu Principal"
+
+msgid "translator-credits"
+msgstr "Luiz-Fernandes https://github.com/Luiz-C-Lima"

--- a/po/tr.po
+++ b/po/tr.po
@@ -105,4 +105,4 @@ msgid "Main Menu"
 msgstr "Ana Menü"
 
 msgid "translator-credits"
-msgstr ""
+msgstr "Sabri Ünal"

--- a/po/tr.po
+++ b/po/tr.po
@@ -103,3 +103,6 @@ msgstr "Yalnızca etkinken geçerlidir"
 
 msgid "Main Menu"
 msgstr "Ana Menü"
+
+msgid "translator-credits"
+msgstr ""

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -35,6 +35,7 @@ export class EN_UI_LABELS {
   // we don't advertise tray icon support
   static Show: string;
   static "Stimulator is running in the backround": string;
+  static "translator-credits": string;
 }
 
 @translate

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "طلب تأكيد",
     "Behavior on Closing": "السلوك عند الإغلاق",
     "Applies only while active": "ينطبق فقط أثناء التشغيل",
-    "Main Menu": "القائمة الرئيسية"
+    "Main Menu": "القائمة الرئيسية",
+    "translator-credits": "Bedis Nbiba https://github.com/sigmaSd"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Ask Confirmation",
     "Behavior on Closing": "Behavior on Closing",
     "Applies only while active": "Applies only while active",
-    "Main Menu": "Main Menu"
+    "Main Menu": "Main Menu",
+    "translator-credits": "translator-credits"
 }

--- a/src/locales/et/translation.json
+++ b/src/locales/et/translation.json
@@ -29,5 +29,6 @@
     "Stimulator is running in the backround": "Stimulaator töötab taustal",
     "Ask Confirmation": "Küsi kinnitust",
     "Behavior on Closing": "Käitumine sulgemisel",
-    "Applies only while active": "Rakendub ainult aktiivses olekus"
+    "Applies only while active": "Rakendub ainult aktiivses olekus",
+    "translator-credits": "Meybo Nõmme https://github.com/meybonomme"
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Demander confirmation",
     "Behavior on Closing": "Comportement à la fermeture",
     "Applies only while active": "S'applique uniquement lorsqu'actif",
-    "Main Menu": "Menu Principal"
+    "Main Menu": "Menu Principal",
+    "translator-credits": "Bedis Nbiba https://github.com/sigmaSd"
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Chiedi conferma",
     "Behavior on Closing": "Comportamento alla chiusura",
     "Applies only while active": "Si applica solo mentre è attivo",
-    "Main Menu": "Menù principale"
+    "Main Menu": "Menù principale",
+    "translator-credits": "Albano Battistella https://github.com/albanobattistella"
 }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "確認する",
     "Behavior on Closing": "終了する際の設定",
     "Applies only while active": "作動中のみ適用されます",
-    "Main Menu": "メインメニュー"
+    "Main Menu": "メインメニュー",
+    "translator-credits": "Nicholas La Roux https://github.com/larouxn"
 }

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Om bevestiging vragen",
     "Behavior on Closing": "Actie na afsluiten",
     "Applies only while active": "Alleen indien actief",
-    "Main Menu": "Hoofdmenu"
+    "Main Menu": "Hoofdmenu",
+    "translator-credits": "Heimen Stoffels https://github.com/Vistaus"
 }

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Pedir Confirmação",
     "Behavior on Closing": "Comportamento Durante Fechamento",
     "Applies only while active": "Aplica-se apenas enquanto ativo",
-    "Main Menu": "Menu Principal"
+    "Main Menu": "Menu Principal",
+    "translator-credits": "Luiz-Fernandes https://github.com/Luiz-C-Lima"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -29,5 +29,6 @@
     "Ask Confirmation": "Onay İste",
     "Behavior on Closing": "Kapatma Davranışı",
     "Applies only while active": "Yalnızca etkinken geçerlidir",
-    "Main Menu": "Ana Menü"
+    "Main Menu": "Ana Menü",
+    "translator-credits": ""
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -30,5 +30,5 @@
     "Behavior on Closing": "Kapatma Davranışı",
     "Applies only while active": "Yalnızca etkinken geçerlidir",
     "Main Menu": "Ana Menü",
-    "translator-credits": ""
+    "translator-credits": "Sabri Ünal"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -377,6 +377,7 @@ export class MainWindow {
     dialog.set_developer_name("Bedis Nbiba");
     dialog.set_developers(["Bedis Nbiba <bedisnbiba@gmail.com>"]);
     dialog.set_designers(["Meybo Nõmme <meybo@meybo.ee>"]);
+    dialog.set_translator_credits(UI_LABELS["translator-credits"]);
     dialog.set_license_type(Gtk.License.MIT_X11);
     dialog.set_website("https://github.com/sigmaSd/stimulator");
     dialog.set_issue_url(


### PR DESCRIPTION
Ignore Merge remote branch “origin/master”, it's empty and useless, just my mistake