### PR TITLE
Add `vcs-browser` URL to manifest

### DIFF
--- a/distro/io.github.sigmasd.stimulator.metainfo.xml
+++ b/distro/io.github.sigmasd.stimulator.metainfo.xml
@@ -47,6 +47,7 @@
 
   <url type="homepage">https://github.com/sigmaSd/stimulator</url>
   <url type="bugtracker">https://github.com/sigmaSd/stimulator/issues</url>
+  <url type="vcs-browser">https://github.com/flathub/io.github.sigmasd.stimulator</url>
 
   <content_rating type="oars-1.1" />
 


### PR DESCRIPTION
Proposing we add the flathub package vcs-browser URL to the manifest at request of this [linter comment](https://github.com/flathub/io.github.sigmasd.stimulator/pull/37#issuecomment-4302065757). I _think_ it makes sense to use the flathub repo as it's the flathub linter that is requesting this URL be added.

<img width="1554" height="280" alt="Screenshot From 2026-04-23 15-50-11" src="https://github.com/user-attachments/assets/d2421a11-7ae3-4300-9198-5221be6054dd" />
<img width="2108" height="216" alt="Screenshot From 2026-04-23 16-10-41" src="https://github.com/user-attachments/assets/6c6c485a-690d-4536-a78b-89f939cfd4a3" />

References
- https://docs.flathub.org/docs/for-app-authors/linter#appstream-missing-vcs-browser-url
- https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url
- https://github.com/flathub-infra/vorarbeiter/actions/runs/24821824609/job/72648221344